### PR TITLE
Timer should only be active if there still is items in the eventloop.

### DIFF
--- a/circuit-breaker.js
+++ b/circuit-breaker.js
@@ -83,7 +83,7 @@
       self._buckets.push(self._createBucket());
     };
 
-    setInterval(tick, bucketDuration);
+    setInterval(tick, bucketDuration).unref();
   };
 
   CircuitBreaker.prototype._createBucket = function() {


### PR DESCRIPTION
Added `unref()` to the setInterval(). This ensures that the lib will
not keep node running if everything else has been stopped.

https://nodejs.org/api/timers.html#timers_unref