### PR TITLE
- avoid comparing to null with ==

### DIFF
--- a/circuit-breaker.js
+++ b/circuit-breaker.js
@@ -22,9 +22,9 @@
     this._startTicker();
   };
 
-  CircuitBreaker.OPEN = 0;
-  CircuitBreaker.HALF_OPEN = 1;
-  CircuitBreaker.CLOSED = 2;
+  CircuitBreaker.OPEN = 'OPEN';
+  CircuitBreaker.HALF_OPEN = 'HALF_OPEN';
+  CircuitBreaker.CLOSED = 'CLOSED';
 
   // Public API
   // ----------
@@ -54,7 +54,7 @@
   };
 
   CircuitBreaker.prototype.isOpen = function() {
-    return this._state == CircuitBreaker.OPEN;
+    return this._state === CircuitBreaker.OPEN;
   };
 
   // Private API
@@ -105,7 +105,7 @@
         var bucket = self._lastBucket();
         bucket[prop]++;
 
-        if (self._forced == null) {
+        if (!self._forced) {
           self._updateState();
         }
 
@@ -145,7 +145,7 @@
   CircuitBreaker.prototype._updateState = function() {
     var metrics = this._calculateMetrics();
 
-    if (this._state == CircuitBreaker.HALF_OPEN) {
+    if (this._state === CircuitBreaker.HALF_OPEN) {
       var lastCommandFailed = !this._lastBucket().successes && metrics.errorCount > 0;
 
       if (lastCommandFailed) {


### PR DESCRIPTION
When new breaker is created via new `new CircuitBreaker({...})`, `self._forced` is `undefined` (not `null)`. Now when `_executeCommand` gets called there is:
```
if (self._forced == null) {
  self._updateState();
}
```
Which will be interpreted as `if (undefined == null)`, which will be `true`, and library is on safe side. Now imagine that at sometime you will run `eslint` against this code (http://eslint.org/docs/rules/no-eq-null) and replace above check with `if (self._forced === null)` (which is anyway, safer than using just `==`), whole library would be unusable, right? cause `(undefined === null)` will lead to `false`. Problem can easily be solved with `if(!self._forced)` as proposed in PR, cause it will return `true` if `self._forced` is `undefined` or `null`.

Other than that there is also proposal to use `===` instead of `==` in whole lib, and also using string constants such as `OPEN`, `HALF_OPEN` and `CLOSED` instead of `0`, `1`, `2`, it improves readability, and if you decide to merge PR it is also must have, otherwise when `self._forced` is equal to `0`, than
`if (!self._forced)` would be interpreted as `true` because of `if(!0)`

**Tests results with proposed changes:**
```
Running "jshint:all" (jshint) task
>> 2 files lint free.

Running "jasmine:all" (jasmine) task
Testing jasmine specs via phantom
..........................
26 specs in 0.011s.
>> 0 failures

Done, without errors.
```