### PR TITLE
Add a destroy method to the Circuit Breaker

### DIFF
--- a/circuit-breaker.js
+++ b/circuit-breaker.js
@@ -57,6 +57,10 @@
     return this._state == CircuitBreaker.OPEN;
   };
 
+  CircuitBreaker.prototype.destroy = function(){
+    clearInterval(this._interval);
+  };
+
   // Private API
   // -----------
 
@@ -83,7 +87,7 @@
       self._buckets.push(self._createBucket());
     };
 
-    setInterval(tick, bucketDuration);
+    this._interval = setInterval(tick, bucketDuration);
   };
 
   CircuitBreaker.prototype._createBucket = function() {

--- a/spec/circuit_breaker_spec.js
+++ b/spec/circuit_breaker_spec.js
@@ -394,6 +394,15 @@ describe('CircuitBreaker', function() {
       expect(command).toHaveBeenCalled();
       expect(breaker.isOpen()).toBe(false);
     });
+  });
 
+  describe('destroy', function(){
+    it('should stop creating new buckets', function(){
+      // Let it run to create some bucket
+      jasmine.Clock.tick(5001);
+
+      breaker.destroy();
+      expect(breaker._buckets.length).toEqual(6);
+    });
   });
 });


### PR DESCRIPTION
This method only stop the creation of new buckets.

As it stands the current implementation keeps node processes from shutting down. Being able to clear the interval resolves this.